### PR TITLE
Cleanup the helm-docs checking script

### DIFF
--- a/.github/helm-docs.sh
+++ b/.github/helm-docs.sh
@@ -3,10 +3,14 @@ set -euo pipefail
 
 HELM_DOCS_VERSION="1.11.0"
 
+TMPDIR=$(mktemp -d)
+
 # install helm-docs
-curl --silent --show-error --fail --location --output /tmp/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
-tar -xf /tmp/helm-docs.tar.gz helm-docs
+curl --silent --show-error --fail --location --output ${TMPDIR}/helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v"${HELM_DOCS_VERSION}"/helm-docs_"${HELM_DOCS_VERSION}"_Linux_x86_64.tar.gz
+tar -xf ${TMPDIR}/helm-docs.tar.gz -C ${TMPDIR} helm-docs
 
 # validate docs
-./helm-docs
+${TMPDIR}/helm-docs
 git diff --exit-code
+
+rm -r ${TMPDIR}


### PR DESCRIPTION
Makes it properly use a temporary directory